### PR TITLE
Example of using .ocamlinit

### DIFF
--- a/p3/.ocamlinit
+++ b/p3/.ocamlinit
@@ -1,0 +1,2 @@
+open P3;;
+#install_printer Regexp.regexp_pp;;

--- a/p3/src/regexp.ml
+++ b/p3/src/regexp.ml
@@ -26,7 +26,9 @@ let fresh =
 
 let regexp_to_nfa re = failwith "unimplemented"
 
-let regexp_to_string r = failwith "unimplemented"
+let regexp_to_string r = "example"
+
+let regexp_pp f s = Format.pp_print_text f (regexp_to_string s)
 
 (*****************************************************************)
 (* Below this point is parser code that YOU DO NOT NEED TO TOUCH *)

--- a/p3/src/regexp.mli
+++ b/p3/src/regexp.mli
@@ -16,4 +16,6 @@ val regexp_to_string : regexp_t -> string
 val string_to_regexp : string -> regexp_t
 val string_to_nfa : string -> (int, char) Nfa.nfa_t
 
+val regexp_pp : Format.formatter -> regexp_t -> unit
+
 exception IllegalExpression of string


### PR DESCRIPTION
…to open toplevel module and install printer for `Regexp.regexp_t`.

Here's an example utop session:

```
utop # Regexp.string_to_regexp "(a|b)*";;
- : Regexp.regexp_t = example
```

See #2 .